### PR TITLE
PADV-2238 fix: use the correct path route in the principal view

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,4 @@
 export const xtremeLabsUrl = `${process.env.LMS_BASE_URL}/xtreme_labs_plugin`;
 export const defaultErrorMessage = 'An unexpected error occurred. Please try again later.';
 export const mfeBaseUrl = '/xtreme-labs-dashboard/:courseId';
+export const course = '/:courseId';

--- a/src/views/index.jsx
+++ b/src/views/index.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Route, useLocation } from 'react-router-dom';
 
-import { mfeBaseUrl } from 'constants';
+import { course } from 'constants';
 
 import DashboardLaunchButton from 'shared/DashboardLaunchButton';
 
@@ -32,7 +32,7 @@ const App = () => {
   return (
     <Route
       exact
-      path={`${mfeBaseUrl}`}
+      path={`${course}`}
       render={(props) => (
         <DashboardLaunchButton
           {...props}

--- a/src/views/test/index.test.jsx
+++ b/src/views/test/index.test.jsx
@@ -8,14 +8,14 @@ import App from '../index';
 jest.mock('../../shared/DashboardLaunchButton', () => () => <div>Mocked DashboardLaunchButton Component</div>);
 
 jest.mock('constants', () => ({
-  mfeBaseUrl: '/base-url',
+  course: '/:courseId',
 }));
 
 describe('App Component', () => {
   it('renders DashboardLaunchButton component by default', async () => {
     await act(async () => {
       render(
-        <MemoryRouter initialEntries={['/base-url']}>
+        <MemoryRouter initialEntries={['/:courseId']}>
           <App />
         </MemoryRouter>,
       );


### PR DESCRIPTION
## Description

This PR solve the problem path in stage and production environments. When we go to https://{lms_base}/xtreme-labs-dashboard/{course_id} we found a black view, but when we go to https://{lms_base}/xtreme-labs-dashboard/xtreme-labs-dashboard/{course_id}, we can see the correct view.

## How to test

We can not to test in devstack, because the configuration is different in tutor. So we need to test in stage

## Jira issue

* https://agile-jira.pearson.com/browse/PADV-2238